### PR TITLE
Various UX improvements

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -14,6 +14,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { OrientabilityType, SURFACES } from "../../constants";
 import { ChevronDoubleUpIcon } from "@heroicons/react/20/solid";
+import { BoardGrid } from "../Grid/BoardGrid";
 
 export const Board = forwardRef(({ gridArea }: { gridArea: string }, ref) => {
   const { paintedGrid, surface } = useContext(GameStateContext);
@@ -59,14 +60,14 @@ export const Board = forwardRef(({ gridArea }: { gridArea: string }, ref) => {
           }[surface.orientability.w]
         }
       </div>
-      <Grid
-        paintedGrid={paintedGrid}
-        gridArea="grid"
-        borderColor={darkMode ? "#F3F4F6" : "white"}
-        pentominoSize={appPreferences.pentominoSize}
-        board={true}
-        ref={ref}
-      ></Grid>
+      <BoardGrid paintedGrid={paintedGrid} gridArea="grid" ref={ref}>
+        <Grid
+          paintedGrid={paintedGrid}
+          borderColor={darkMode ? "#F3F4F6" : "white"}
+          pentominoSize={appPreferences.pentominoSize}
+          board={true}
+        />
+      </BoardGrid>
     </div>
   );
 });

--- a/src/components/DarkModeButton/DarkModeButton.tsx
+++ b/src/components/DarkModeButton/DarkModeButton.tsx
@@ -7,8 +7,7 @@ export const DarkModeButton = () => {
   const ChangeIcon = darkMode === true ? SunIcon : MoonIcon;
   return (
     <ChangeIcon
-      className="cursor-pointer"
-      width={25}
+      className="cursor-pointer h-10 w-10 text-gray-800 dark:text-gray-300"
       onClick={() => {
         updateDarkMode(!darkMode);
       }}

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -34,7 +34,7 @@ const GameContent = () => {
       <Wordmark gridArea="wordmark" />
       <Header style={{ gridArea: "header" }}></Header>
       <div
-        className="flex flex-row items-start justify-end w-full h-full pr-2 gap-1 max-w-[100vw]"
+        className="flex flex-row items-start justify-end w-full h-full pr-2 gap-2 max-w-[100vw]"
         style={{ gridArea: "settings" }}
       >
         <Settings></Settings>

--- a/src/components/GameStateProvider/gameConstants.ts
+++ b/src/components/GameStateProvider/gameConstants.ts
@@ -6,4 +6,5 @@ export interface GamePreferences {
 export const DEFAULT_GAME_PREFERENCES = {
   showKeyboardIndicators: false,
   defaultRandomColors: false,
+  defaultAddTerrain: true,
 };

--- a/src/components/Grid/BoardGrid.tsx
+++ b/src/components/Grid/BoardGrid.tsx
@@ -1,0 +1,36 @@
+import { PaintedCell, SURFACES } from "../../constants";
+import clsx from "clsx";
+import { ReactNode, RefObject, forwardRef, memo, useContext } from "react";
+import { GameStateContext } from "../GameStateProvider/GameStateProvider";
+
+export const BoardGrid = memo(
+  forwardRef(
+    (
+      {
+        paintedGrid,
+        gridArea,
+        children,
+      }: {
+        paintedGrid: PaintedCell[][];
+        gridArea: string;
+        children: ReactNode;
+      },
+      ref
+    ) => {
+      const { surface } = useContext(GameStateContext);
+      return (
+        <div
+          className={clsx("grid grid-flow-row w-fit h-fit")}
+          style={{
+            gridTemplateRows: `repeat(${paintedGrid.length}, minmax(0, 1fr))`,
+            gridTemplateColumns: `repeat(${paintedGrid[0].length}, minmax(0, 1fr))`,
+            gridArea,
+          }}
+          ref={surface.name === SURFACES.Rectangle.name ? (ref as RefObject<HTMLDivElement>) : undefined}
+        >
+          {children}
+        </div>
+      );
+    }
+  )
+);

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,53 +1,32 @@
-import { PaintedCell, SURFACES } from "../../constants";
+import { PaintedCell } from "../../constants";
 import { Cell } from "../Cell/Cell";
-import clsx from "clsx";
-import { RefObject, forwardRef, memo, useContext } from "react";
-import { GameStateContext } from "../GameStateProvider/GameStateProvider";
 
-const GridComponent = forwardRef(
-  (
-    {
-      paintedGrid,
-      pentominoSize,
-      gridArea,
-      borderColor = "white",
-      board = false,
-    }: {
-      paintedGrid: PaintedCell[][];
-      pentominoSize: number;
-      gridArea?: string;
-      borderColor?: string;
-      board?: boolean;
-    },
-    ref
-  ) => {
-    const { surface } = useContext(GameStateContext);
-    return (
-      <div
-        className={clsx("grid grid-flow-row w-fit h-fit")}
-        style={{
-          gridTemplateRows: `repeat(${paintedGrid.length}, minmax(0, 1fr))`,
-          gridTemplateColumns: `repeat(${paintedGrid[0].length}, minmax(0, 1fr))`,
-          gridArea,
-        }}
-        ref={surface.name === SURFACES.Rectangle.name ? (ref as RefObject<HTMLDivElement>) : undefined}
-      >
-        {paintedGrid.map((r, x) =>
-          r.map((c, y) => (
-            <Cell
-              key={`cell-${x}_${y}`}
-              cell={c}
-              x={x}
-              y={y}
-              pentominoSize={pentominoSize}
-              borderColor={borderColor}
-              board={board}
-            ></Cell>
-          ))
-        )}
-      </div>
-    );
-  }
-);
-
-export const Grid = memo(GridComponent);
+export const Grid = ({
+  paintedGrid,
+  pentominoSize,
+  borderColor = "white",
+  board = false,
+}: {
+  paintedGrid: PaintedCell[][];
+  pentominoSize: number;
+  borderColor?: string;
+  board?: boolean;
+}) => {
+  return (
+    <>
+      {paintedGrid.map((r, x) =>
+        r.map((c, y) => (
+          <Cell
+            key={`cell-${x}_${y}`}
+            cell={c}
+            x={x}
+            y={y}
+            pentominoSize={pentominoSize}
+            borderColor={borderColor}
+            board={board}
+          ></Cell>
+        ))
+      )}
+    </>
+  );
+};

--- a/src/components/Grid/InfoGrid.tsx
+++ b/src/components/Grid/InfoGrid.tsx
@@ -1,0 +1,29 @@
+import { PlacedPentomino } from "../../constants";
+import clsx from "clsx";
+import { ReactNode, memo, useContext } from "react";
+import { GameStateContext } from "../GameStateProvider/GameStateProvider";
+import { PENTOMINOES } from "../../pentominoes";
+
+export const InfoGrid = memo(({ grid, children }: { grid: PlacedPentomino[][]; children: ReactNode }) => {
+  const { setGrid } = useContext(GameStateContext);
+  return (
+    <div
+      className={clsx("grid grid-flow-row w-fit h-fit cursor-pointer")}
+      style={{
+        gridTemplateRows: `repeat(${grid.length}, minmax(0, 1fr))`,
+        gridTemplateColumns: `repeat(${grid[0].length}, minmax(0, 1fr))`,
+      }}
+      onClick={() => {
+        let gridIsEmpty = true;
+        grid.forEach((row) =>
+          row.forEach((cell) => {
+            if (cell.pentomino.name !== PENTOMINOES.None.name) gridIsEmpty = false;
+          })
+        );
+        if (gridIsEmpty || confirm("Reset your board? You won't be able to undo.")) setGrid(grid);
+      }}
+    >
+      {children}
+    </div>
+  );
+});

--- a/src/components/Information/Information.tsx
+++ b/src/components/Information/Information.tsx
@@ -10,6 +10,7 @@ import { AppStateContext } from "../AppStateProvider/AppStateProvider";
 import clsx from "clsx";
 import { ArrowDownIcon, ArrowRightIcon, ArrowUpIcon, ArrowLeftIcon } from "@heroicons/react/20/solid";
 import { getPaintedBoard } from "../GameStateProvider/paintGrid";
+import { InfoGrid } from "../Grid/InfoGrid";
 
 interface GridExample {
   w: number;
@@ -79,13 +80,13 @@ const gridExampleStructure: GridExample[] = [
     ],
   },
   {
-    w: 6,
-    l: 10,
+    w: 10,
+    l: 6,
     terrain: [],
   },
   {
-    w: 5,
-    l: 12,
+    w: 12,
+    l: 5,
     terrain: [],
   },
 ];
@@ -101,7 +102,7 @@ const exampleGrids = gridExampleStructure.map((e) => {
 export const Information = () => {
   const { darkMode } = useContext(AppStateContext);
   return (
-    <Modal trigger={<QuestionMarkCircleIcon className="h-6 w-6" />}>
+    <Modal trigger={<QuestionMarkCircleIcon className="h-10 w-10 text-gray-800 dark:text-gray-300" />}>
       <Dialog.Title className="text-center font-bold text-md mb-2">About Pentominoes</Dialog.Title>
       <p className="mb-2">
         Pentominoes are tiles of area 5. There are 12 distinct pentominoes, up to rotation & reflection, with each tile
@@ -111,9 +112,13 @@ export const Information = () => {
         {<InformationPentominoDisplay p="Y" />}) distinct orientations.
       </p>
       <p className="mb-2">
-        There are several different ways to enjoy the puzzle game of Pentominoes, but the common theme is that you will
-        try to fully tile a grid of total area 60 (5x12=60) such that no pentominoes overlap or fall off the edge, and
-        no empty squares remain (other than whatever terrain you choose to place before starting to solve the puzzle).
+        This puzzle game also provides a one-square-unit-area tile that you can use as terrain (the{" "}
+        <InformationPentominoDisplay p="R"></InformationPentominoDisplay> tile).
+      </p>
+      <p className="mb-2">
+        There are several different ways to enjoy Pentominoes, but the common theme is that you will try to fully tile a
+        grid of total area 60 (5x12=60) such that no pentominoes overlap or fall off the edge, and no empty squares
+        remain (other than whatever terrain you choose to place before starting to solve the puzzle).
       </p>
       <p className="mb-2">
         Generally, you want to use one of each pentomino to tile the board, but you're welcome to use this app however
@@ -191,11 +196,13 @@ export const Information = () => {
       <div className="flex flex-row flex-wrap gap-3 justify-center">
         {exampleGrids.map((grid, i) => (
           <div key={i} className="flex flex-col items-center justify-center">
-            <Grid
-              paintedGrid={getPaintedBoard(grid, SURFACES.Rectangle, undefined, false)}
-              pentominoSize={4}
-              borderColor={darkMode ? "#F3F4F6" : "black"}
-            ></Grid>
+            <InfoGrid grid={grid}>
+              <Grid
+                pentominoSize={4}
+                paintedGrid={getPaintedBoard(grid, SURFACES.Rectangle, undefined, false)}
+                borderColor={darkMode ? "#F3F4F6" : "black"}
+              />
+            </InfoGrid>
             Width: {grid[0].length} Length: {grid.length}
           </div>
         ))}

--- a/src/components/PentominoDisplay/PentominoDisplay.tsx
+++ b/src/components/PentominoDisplay/PentominoDisplay.tsx
@@ -59,6 +59,7 @@ export const PentominoDisplay = ({
     <span
       {...rest}
       className={clsx("grid grid-flow-row w-fit h-fit display-block", PENTOMINO_DIMENSIONS[p.shape[0].length])}
+      title={pentomino.display || pentomino.name}
     >
       {p.shape.map((row, x) =>
         row.map((cell, y) => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -49,6 +49,8 @@ export const Settings = () => {
     setShowKeyboardIndicators,
     defaultRandomColors,
     updateDefaultRandomColors,
+    defaultAddTerrain,
+    updateDefaultAddTerrain,
   } = useContext(GameStateContext);
 
   const [currentState, setCurrentState] = useState<CurrentState>({ ...DEFAULT_SETTINGS_CONFIG });
@@ -65,7 +67,7 @@ export const Settings = () => {
 
   return (
     <Modal
-      trigger={<Cog8ToothIcon className="h-6 w-6" />}
+      trigger={<Cog8ToothIcon className="h-10 w-10 text-gray-800 dark:text-gray-300" />}
       onOpenAutoFocus={() => {
         setCurrentState({
           height: grid.length,
@@ -75,10 +77,11 @@ export const Settings = () => {
           displayColors: appPreferences.displayColors,
           pentominoColors,
           surface,
-          showKeyboardIndicators,
           copyImage: appPreferences.copyImage,
           showCdot: appPreferences.showCdot,
+          showKeyboardIndicators,
           defaultRandomColors,
+          defaultAddTerrain,
         });
         setShowErrors(false);
         setWarnGridReset(false);
@@ -123,6 +126,7 @@ export const Settings = () => {
           setShowKeyboardIndicators(currentState.showKeyboardIndicators);
 
           updateDefaultRandomColors(currentState.defaultRandomColors);
+          updateDefaultAddTerrain(currentState.defaultAddTerrain);
           setOpen(false);
         }}
       >
@@ -348,6 +352,20 @@ export const Settings = () => {
             checked={currentState.defaultRandomColors}
             onChange={(e) => {
               setCurrentState({ ...currentState, defaultRandomColors: e.target.checked });
+            }}
+          />
+        </fieldset>
+        <fieldset className="flex gap-4 items-center mb-4">
+          <label className="text-right" htmlFor="initterrain">
+            Add 4 squares of terrain when URL is empty?
+          </label>
+          <input
+            className="bg-white dark:bg-slate-950"
+            type="checkbox"
+            id="initterrain"
+            checked={currentState.defaultAddTerrain}
+            onChange={(e) => {
+              setCurrentState({ ...currentState, defaultAddTerrain: e.target.checked });
             }}
           />
         </fieldset>

--- a/src/components/Settings/settingsConstants.ts
+++ b/src/components/Settings/settingsConstants.ts
@@ -15,6 +15,7 @@ export interface CurrentState {
   copyImage: boolean;
   showCdot: boolean;
   defaultRandomColors: boolean;
+  defaultAddTerrain: boolean;
 }
 
 export const DEFAULT_SETTINGS_CONFIG: CurrentState = {

--- a/src/components/TopToolbar/TopToolbar.tsx
+++ b/src/components/TopToolbar/TopToolbar.tsx
@@ -24,7 +24,7 @@ const TopToolbar = ({ ...rest }) => {
         <div className="scale-x-[-1]">
           <ReloadIcon />
         </div>
-        Rotate Left
+        Rotate
       </ToolbarButton>
       <ToolbarButton
         onClick={() => {
@@ -34,29 +34,29 @@ const TopToolbar = ({ ...rest }) => {
         className="flex flex-row items-center gap-1"
       >
         <ReloadIcon />
-        Rotate Right
+        Rotate
       </ToolbarButton>
       <ToolbarButton
         onClick={() => {
           orientationDispatch({ type: OrientationActionType.reflect, direction: ReflectionDirection.X });
         }}
-        aria-label="Reflect X"
+        aria-label="Reflect over the X-axis"
         className="flex flex-row items-center"
       >
         <div className="rotate-90">
           <DoubleEndedArrow />
         </div>
-        Reflect X
+        Reflect
       </ToolbarButton>
       <ToolbarButton
         onClick={() => {
           orientationDispatch({ type: OrientationActionType.reflect, direction: ReflectionDirection.Y });
         }}
-        aria-label="Reflect Y"
+        aria-label="Reflect over the Y-axis"
         className="flex flex-row items-center gap-1"
       >
         <DoubleEndedArrow />
-        Reflect Y
+        Reflect
       </ToolbarButton>
     </Toolbar.Root>
   );

--- a/src/pentominoes.ts
+++ b/src/pentominoes.ts
@@ -17,6 +17,7 @@ interface Shapes {
 
 export interface Pentomino {
   name: string;
+  display?: string;
   shapes: Shapes;
 }
 
@@ -26,6 +27,7 @@ interface Pentominoes {
 
 interface PentominoPrimitive {
   name: string;
+  display?: string;
   shape: number[][];
 }
 
@@ -129,7 +131,8 @@ const pentominoPrimitives: PentominoPrimitive[] = [
     shape: [[0]],
   },
   {
-    name: "R", // Terrain
+    name: "R",
+    display: "Terrain",
     shape: [[2]],
   },
 ];
@@ -140,6 +143,7 @@ pentominoPrimitives.map((p) => {
   const reflectedShape = reflectX(p.shape);
   const expandedPentomino: Pentomino = {
     name: p.name,
+    display: p.display,
     shapes: {
       0: [{ center: center(p.shape), shape: p.shape }],
       1: [{ center: center(reflectedShape), shape: reflectedShape }],


### PR DESCRIPTION
* Increase size of settings icons (Closes #64)
* Default to showing 4 terrain in the default board when there's no URL settings (Closes #66)
* Make grids in Information modal clickable (Closes #62)
* Remove text `Left`, `Right`, `X`, `Y` from toolbar (Closes #61)
* Add title text to all tiles & explain terrain in Information modal (Closes #60)